### PR TITLE
Return totality of defaults intermediate dictionary contents.

### DIFF
--- a/python3-utility-mill.spec
+++ b/python3-utility-mill.spec
@@ -3,9 +3,9 @@
 %define repo_name python-support-utility-mill
 %define repo_branch main
 
-%define version 1.0.6
-%define unmangled_version 1.0.6
-%define release 2
+%define version 1.0.7
+%define unmangled_version 1.0.7
+%define release 1
 
 Name: python3-%{modname}
 Version: %{version}
@@ -66,6 +66,12 @@ UNKNOWN
 %{python3_sitelib}/python3_utility_mill-%{version}*
 
 %changelog
+* Thu Apr 20 2023 Joe Shimkus <jshimkus@redhat.com> - 1.0.7-1
+- When retrieving a defaults intermediate dictionary from the user defaults
+  get the same from the system defaults and return a copy of that updated
+  from the user defaults.  This provides the totality, at the requested level,
+  of defaults in the dictionary.
+
 * Mon Feb 20 2023 Joe Shimkus <jshimkus@redhat.com> - 1.0.6-2
 - Log defaults lookup attempt from user defaults file.
   This avoids confusion as to whether the user defaults are queried.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import sys
 import yaml
 
 # package_version and the rpm .spec version are to be kept in sync.
-package_version = {"major": 1, "minor": 0, "patch": 6, "release": 2}
+package_version = {"major": 1, "minor": 0, "patch": 7, "release": 1}
 package_name = "utility-mill"
 package_prefix = "mill"
 subpackage_names = ["defaults", "factory", "command"]


### PR DESCRIPTION
User defaults are supposed to only require specifying values to override.  If a request is for an intermediate dictionary (for caching purposes) that dictionary must contain the totality of the defaults at the requested level in order to satisfy a request for any of those defaults.