### PR TITLE
Remove python3-eventlet

### DIFF
--- a/python3-utility-mill.spec
+++ b/python3-utility-mill.spec
@@ -30,7 +30,6 @@ BuildRequires: python39-pyyaml
 %else
 BuildRequires: python3
 BuildRequires: python3-devel
-BuildRequires: python3-eventlet
 BuildRequires: python3-py
 BuildRequires: python3-rpm-macros
 BuildRequires: python3-setuptools


### PR DESCRIPTION
python3-eventlet is no longer available through dnf in Fedora 41. We need to remove it from the requirements in order to build the packages.